### PR TITLE
Fix `id` reference in gene rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -60,7 +60,7 @@ button.onclick = function(){
     var gene = results[x];
     var artistName = gene.artists_connection.edges[0].node.name
     console.log(gene)
-    geneResults.innerHTML += "<br></br><a data-artist='" + artistName + "' href='https://staging.artsy.net/gene/" + gene._id + "' target=\"_blank\">" + gene.name + "</a>"; 
+    geneResults.innerHTML += "<br></br><a data-artist='" + artistName + "' href='https://staging.artsy.net/gene/" + gene.id + "' target=\"_blank\">" + gene.name + "</a>"; 
     
     // add event listent to new <a> elements
   }


### PR DESCRIPTION
We're fetching the `id` Gene attribute from Metaphysics, holding the slug (like `neo-dada` or `impressionism`) but referencing an `_id` attribute when rendering, which isn't currently fetched by our GraphQL query. I don't think we'd prefer it either as it contains an alphanumeric identifier (like '4d90d18fdcdd5f44a500002d`) instead.

This commit updates the rendering to use the fetched `id` attribute value.